### PR TITLE
Fix typo re: name change

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -1,18 +1,18 @@
 # Getting Started
 
-This guide explains how to get started with the `async-job-active_job-adapter` gem.
+This guide explains how to get started with the `async-job-adapter-active_job` gem.
 
 ## Installation
 
 Add the gem to your Rails project:
 
 ``` bash
-$ bundle add async-job-active_job-adapter
+$ bundle add async-job-adapter-active_job
 ```
 
 ## Core Concepts
 
-The `async-job-active_job-adapter` gem provides an Active Job adapter for the `async-job` gem. This allows you to use the `async-job` gem with Rails' built-in Active Job framework.
+The `async-job-adapter-active_job` gem provides an Active Job adapter for the `async-job` gem. This allows you to use the `async-job` gem with Rails' built-in Active Job framework.
 
 - The {ruby Async::Job::ActiveJob::Dispatcher} class manages zero or more queues.
 - The {ruby Async::Job::ActiveJob::Railtie} class provides a convenient interface for configuring the integration.
@@ -34,12 +34,12 @@ Rails.application.configure do
 	config.async_job.define_queue "default" do
 		dequeue Async::Job::Processor::Redis
 	end
-	
+
 	# Create a queue named "local" which uses the Inline backend:
 	config.async_job.define_queue "local" do
 		dequeue Async::Job::Processor::Inline
 	end
-	
+
 	# Set Async::Job as the global Active Job queue adapter:
 	config.active_job.queue_adapter = :async_job
 end
@@ -55,7 +55,7 @@ Rather than using `Async::Job` for all jobs, you could opt in using a specific q
 class MyJob < ApplicationJob
 	queue_adapter :async_job
 	queue_as :local
-	
+
 	# ...
 end
 ```

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Provides an adapter for ActiveJob on top of `Async::Job`.
 
 Please see the [project documentation](https://socketry.github.io/async-job-adapter-active_job/) for more details.
 
-  - [Getting Started](https://socketry.github.io/async-job-adapter-active_job/guides/getting-started/index) - This guide explains how to get started with the `async-job-active_job-adapter` gem.
+  - [Getting Started](https://socketry.github.io/async-job-adapter-active_job/guides/getting-started/index) - This guide explains how to get started with the `async-job-adapter-active_job` gem.
 
 ## Contributing
 


### PR DESCRIPTION
Fix typo, looks like the name of the gem was changed? 

## Types of Changes

- Documentation

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

## Notes

Apologies re: whitespace changes, feel free to disregard the PR and just fix in your repo, or I can update, thanks!