### PR TITLE
Move ActiveJob health signaling off the reactor

### DIFF
--- a/lib/async/job/adapter/active_job/environment.rb
+++ b/lib/async/job/adapter/active_job/environment.rb
@@ -11,6 +11,9 @@ module Async
 			module ActiveJob
 				# The environment for the ActiveJob server.
 				module Environment
+					HEALTH_CHECK_TIMEOUT = "ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_TIMEOUT"
+					HEALTH_CHECK_INTERVAL = "ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_INTERVAL"
+					
 					# The service class to use.
 					def service_class
 						Service
@@ -43,13 +46,41 @@ module Async
 						nil
 					end
 					
+					# The maximum time a worker can go without a health update.
+					# Set `ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_TIMEOUT=0` to disable health checks.
+					def health_check_timeout(environment = ENV)
+						parse_duration(environment, HEALTH_CHECK_TIMEOUT, default: 30, allow_disable: true)
+					end
+					
+					# The interval between health updates.
+					def health_check_interval(environment = ENV)
+						if health_check_timeout = self.health_check_timeout(environment)
+							parse_duration(environment, HEALTH_CHECK_INTERVAL, default: health_check_timeout / 2.0)
+						end
+					end
+					
 					# Options to use when creating the container.
 					def container_options
 						{
 							restart: true,
 							count: self.count,
-							health_check_timeout: 30,
+							health_check_timeout: self.health_check_timeout,
 						}.compact
+					end
+					
+					private
+					
+					def parse_duration(environment, key, default:, allow_disable: false)
+						if value = environment[key]
+							duration = Float(value)
+							
+							return nil if allow_disable && duration <= 0
+							return default if duration <= 0
+							
+							duration
+						else
+							default
+						end
 					end
 				end
 			end

--- a/lib/async/job/adapter/active_job/service.rb
+++ b/lib/async/job/adapter/active_job/service.rb
@@ -15,10 +15,74 @@ module Async
 			module ActiveJob
 				# A job server that can be run as a service.
 				class Service < Async::Service::Generic
+					# Sends periodic health updates from a dedicated Ruby thread so health signaling
+					# remains responsive even if the reactor is temporarily blocked by job code.
+					class HealthReporter
+						def initialize(interval, &block)
+							@interval = interval
+							@block = block
+							@thread = nil
+							@mutex = Mutex.new
+							@condition = ConditionVariable.new
+							@stop_requested = false
+						end
+						
+						def start
+							@mutex.synchronize do
+								return false if @thread
+								
+								@stop_requested = false
+								@thread = Thread.new do
+									Thread.current.report_on_exception = false
+									
+									loop do
+										break if wait_for_stop
+										
+										@block.call
+									end
+								rescue IOError, Errno::EPIPE
+									# The parent container may have already closed the notification pipe.
+								ensure
+									@mutex.synchronize do
+										@thread = nil if @thread.equal?(Thread.current)
+									end
+								end
+							end
+						end
+						
+						def stop
+							thread = @mutex.synchronize do
+								@stop_requested = true
+								@condition.broadcast
+								
+								@thread
+							end
+							
+							thread&.join unless thread == Thread.current
+						end
+						
+						private
+						
+						def wait_for_stop
+							@mutex.synchronize do
+								return true if @stop_requested
+								
+								@condition.wait(@mutex, @interval)
+								
+								@stop_requested
+							end
+						end
+					end
+					
 					# Load the Rails environment and start the job server.
 					def setup(container)
 						container_options = @evaluator.container_options
 						health_check_timeout = container_options[:health_check_timeout]
+						health_check_interval = if @evaluator.respond_to?(:health_check_interval)
+							@evaluator.health_check_interval
+						elsif health_check_timeout
+							health_check_timeout / 2.0
+						end
 						
 						container.run(name: self.name, **container_options) do |instance|
 							evaluator = @environment.evaluator
@@ -28,14 +92,14 @@ module Async
 							dispatcher = evaluator.dispatcher
 							
 							instance.ready!
+							health_reporter = self.start_health_reporter(instance, interval: health_check_interval)
 							
 							Sync do |task|
 								if health_check_timeout
 									task.async(transient: true) do
 										while true
 											instance.name = "#{self.name} (#{dispatcher.status_string})"
-											sleep(health_check_timeout / 2)
-											instance.ready!
+											sleep(health_check_interval)
 										end
 									end
 								end
@@ -54,9 +118,23 @@ module Async
 								
 								barrier.wait
 							ensure
+								health_reporter&.stop
 								barrier.stop
 							end
 						end
+					end
+					
+					private
+					
+					def start_health_reporter(instance, interval:)
+						return unless interval
+						
+						reporter = HealthReporter.new(interval) do
+							instance.ready!
+						end
+						
+						reporter.start
+						reporter
 					end
 				end
 			end

--- a/lib/async/job/adapter/active_job/service.rb
+++ b/lib/async/job/adapter/active_job/service.rb
@@ -118,7 +118,6 @@ module Async
 								
 								barrier.wait
 							ensure
-								health_reporter&.stop
 								barrier.stop
 							end
 						end

--- a/test/async/job/adapter/active_job/environment.rb
+++ b/test/async/job/adapter/active_job/environment.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Carmine Paolino.
+
+require "async/job/adapter/active_job/environment"
+
+describe Async::Job::Adapter::ActiveJob::Environment do
+	let(:environment) do
+		Class.new do
+			extend Async::Job::Adapter::ActiveJob::Environment
+		end
+	end
+	
+	it "has sensible default health timings" do
+		expect(environment.health_check_timeout({})).to be == 30
+		expect(environment.health_check_interval({})).to be == 15.0
+	end
+	
+	it "can override health timings from the environment" do
+		overrides = {
+			"ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_TIMEOUT" => "60",
+			"ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_INTERVAL" => "10",
+		}
+		
+		expect(environment.health_check_timeout(overrides)).to be == 60.0
+		expect(environment.health_check_interval(overrides)).to be == 10.0
+	end
+	
+	it "can disable health checks from the environment" do
+		overrides = {
+			"ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_TIMEOUT" => "0",
+		}
+		
+		expect(environment.health_check_timeout(overrides)).to be_nil
+		expect(environment.health_check_interval(overrides)).to be_nil
+	end
+end

--- a/test/async/job/adapter/active_job/service.rb
+++ b/test/async/job/adapter/active_job/service.rb
@@ -4,6 +4,8 @@
 # Copyright, 2026, by Carmine Paolino.
 
 require "async/job/adapter/active_job/service"
+require "fileutils"
+require "tmpdir"
 
 describe Async::Job::Adapter::ActiveJob::Service::HealthReporter do
 	let(:ready_count) {Thread::Queue.new}
@@ -26,5 +28,66 @@ describe Async::Job::Adapter::ActiveJob::Service::HealthReporter do
 		expect(ready_count.size).to be >= 2
 	ensure
 		reporter.stop
+	end
+end
+
+describe Async::Job::Adapter::ActiveJob::Service do
+	let(:reporter_stops) {[]}
+	let(:reporter) do
+		Object.new.tap do |object|
+			object.define_singleton_method(:stop) do
+				reporter_stops << :stop
+			end
+		end
+	end
+	
+	let(:instance) do
+		Object.new.tap do |object|
+			object.define_singleton_method(:ready!) {}
+			object.define_singleton_method(:name=) {|value| value}
+		end
+	end
+	
+	let(:dispatcher) do
+		Object.new.tap do |object|
+			object.define_singleton_method(:status_string) {"idle"}
+			object.define_singleton_method(:start) {|queue_name| queue_name}
+		end
+	end
+	
+	it "does not stop the health reporter immediately after setup" do
+		Dir.mktmpdir do |root|
+			current_dispatcher = dispatcher
+			current_instance = instance
+			current_reporter = reporter
+			
+			FileUtils.mkdir_p(File.join(root, "config"))
+			File.write(File.join(root, "config/environment.rb"), "# test environment\n")
+			
+			evaluator = Object.new
+			evaluator.define_singleton_method(:container_options) {{health_check_timeout: 1}}
+			evaluator.define_singleton_method(:health_check_interval) {0.01}
+			evaluator.define_singleton_method(:root) {root}
+			evaluator.define_singleton_method(:dispatcher) {current_dispatcher}
+			evaluator.define_singleton_method(:queue_names) {[]}
+			evaluator.define_singleton_method(:name) {"test-service"}
+			
+			environment = Object.new
+			environment.define_singleton_method(:evaluator) {evaluator}
+			
+			container = Object.new
+			container.define_singleton_method(:run) do |name:, **options, &block|
+				block.call(current_instance)
+			end
+			
+			service = subject.new(environment, evaluator)
+			service.define_singleton_method(:start_health_reporter) do |current_instance, interval:|
+				current_reporter
+			end
+			
+			service.setup(container)
+		end
+		
+		expect(reporter_stops).to be(:empty?)
 	end
 end

--- a/test/async/job/adapter/active_job/service.rb
+++ b/test/async/job/adapter/active_job/service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Carmine Paolino.
+
+require "async/job/adapter/active_job/service"
+
+describe Async::Job::Adapter::ActiveJob::Service::HealthReporter do
+	let(:ready_count) {Thread::Queue.new}
+	let(:reporter) do
+		subject.new(0.01) do
+			ready_count << :ready
+		end
+	end
+	
+	it "sends health updates from a dedicated thread" do
+		thread = reporter.start
+		
+		expect(thread).to be_a(Thread)
+		
+		deadline = Time.now + 0.2
+		while ready_count.size < 2 && Time.now < deadline
+			sleep(0.01)
+		end
+		
+		expect(ready_count.size).to be >= 2
+	ensure
+		reporter.stop
+	end
+end


### PR DESCRIPTION
Closes #20.
Related: socketry/async-job-processor-redis#7

This moves the ActiveJob adapter's periodic `ready!` health signaling off the reactor and onto a dedicated Ruby thread.

The goal is to make the adapter resilient to arbitrary `perform_now` workloads. A blocking job may make the worker slower to do useful work, but it should not stop health signaling just because the job body did not yield back to the reactor quickly enough.

What changed:

- Added a small `HealthReporter` helper that sends periodic `instance.ready!` updates from a dedicated thread.
- Kept the status/name updater on the reactor, because it is informational rather than part of the correctness boundary.
- Added `ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_TIMEOUT` and `ASYNC_JOB_ADAPTER_ACTIVE_JOB_HEALTH_CHECK_INTERVAL`.
- Added tests for both the environment-level configuration and the threaded health reporter.

Validation:

- `bundle exec sus`
