### PR TITLE
Add optional graceful drain of running jobs on stop signals

### DIFF
--- a/lib/async/job/adapter/active_job/environment.rb
+++ b/lib/async/job/adapter/active_job/environment.rb
@@ -42,6 +42,14 @@ module Async
 					def count
 						nil
 					end
+
+					# How long to wait for running jobs to finish when the server is asked to stop, before they are cancelled. When nil (the default), running jobs are cancelled immediately, as before.
+					# @returns [Numeric | nil]
+					def drain_timeout
+						if drain_timeout = ENV["ASYNC_JOB_ADAPTER_ACTIVE_JOB_DRAIN_TIMEOUT"]
+							Float(drain_timeout)
+						end
+					end
 					
 					# Options to use when creating the container.
 					def container_options

--- a/lib/async/job/adapter/active_job/service.rb
+++ b/lib/async/job/adapter/active_job/service.rb
@@ -8,6 +8,7 @@ require "console/event/failure"
 
 require "async"
 require "async/barrier"
+require "async/notification"
 
 module Async
 	module Job
@@ -19,16 +20,17 @@ module Async
 					def setup(container)
 						container_options = @evaluator.container_options
 						health_check_timeout = container_options[:health_check_timeout]
-						
+						drain_timeout = @evaluator.drain_timeout
+
 						container.run(name: self.name, **container_options) do |instance|
 							evaluator = @environment.evaluator
-							
+
 							require File.expand_path("config/environment", evaluator.root)
-							
+
 							dispatcher = evaluator.dispatcher
-							
+
 							instance.ready!
-							
+
 							Sync do |task|
 								if health_check_timeout
 									task.async(transient: true) do
@@ -39,9 +41,9 @@ module Async
 										end
 									end
 								end
-								
+
 								barrier = Async::Barrier.new
-								
+
 								# Start all the named queues:
 								evaluator.queue_names.each do |queue_name|
 									barrier.async do
@@ -51,8 +53,43 @@ module Async
 										Console::Event::Failure.for(error).emit(self, "Queue failed!")
 									end
 								end
-								
-								barrier.wait or sleep
+
+								if drain_timeout
+									# A stop signal unwinds the reactor before any rescue can run (the scheduler turns it into a root task stop), so to drain we must intercept the signal itself. A self-pipe wakes a task which stops the queues from fetching, waits for running jobs to finish, then shuts down. Jobs that outlive the timeout are cancelled and recovered as abandoned jobs, as before.
+									reader, writer = ::IO.pipe
+
+									%w[INT TERM].each do |signal|
+										::Signal.trap(signal) do
+											writer.write_nonblock(".")
+										rescue ::IO::WaitWritable, ::IOError
+											# Already draining or shutting down.
+										end
+									end
+
+									shutdown = Async::Notification.new
+									drained = false
+
+									task.async(transient: true, annotation: "Draining on stop signal.") do
+										reader.read(1)
+
+										evaluator.queue_names.each do |queue_name|
+											server = dispatcher[queue_name].server
+
+											if server.respond_to?(:drain)
+												Console.info(self, "Draining queue...", queue_name: queue_name, timeout: drain_timeout)
+												server.drain(timeout: drain_timeout)
+											end
+										end
+
+										drained = true
+										shutdown.signal
+									end
+
+									# The queue tasks above do not finish (the processors' background loops are their children), so wait for the drain instead:
+									shutdown.wait unless drained
+								else
+									barrier.wait or sleep
+								end
 							ensure
 								barrier&.stop
 							end


### PR DESCRIPTION
Companion to socketry/async-job-processor-redis#9 (the `drain` half; this PR is inert without it, and degrades gracefully against processors that do not respond to `drain`).

When the service is stopped (e.g. a deploy sends SIGINT/SIGTERM), the reactor teardown cancels all running jobs mid-flight. With at-least-once processors they are requeued and re-run, which duplicates work and side effects. For our LLM workload, every deploy re-ran 60-920 jobs, and with several deploys a day the duplicated calls added up.

This adds an opt-in `drain_timeout` to the environment (default from `ASYNC_JOB_ADAPTER_ACTIVE_JOB_DRAIN_TIMEOUT`, nil = current behavior). When set, the service traps INT/TERM via a self-pipe into a task that asks each queue's server to `drain(timeout:)` — stop fetching, finish running jobs — before letting the normal teardown proceed. Jobs that outlive the timeout are cancelled and recovered as abandoned, exactly as today.

The signal has to be intercepted before it reaches the reactor: by the time it surfaces as a root-task stop, the job tasks are already being cancelled, so a rescue inside the `Sync` block is too late. If there is a more idiomatic place in async-service/async-container to hook "about to stop, may I finish first?", happy to rework this — the trap-based approach is what we could build from the outside, not necessarily the design you'd want inside.

One deployment consideration worth documenting if this lands: the drain window needs to fit inside the supervisor's kill grace (`Async::Service::Controller.run(configuration, graceful_stop: ...)`, default 10s) and the orchestrator's stop timeout (for ECS Fargate, `stopTimeout` max 120s).
