### PR TITLE
Improve project documentation guides

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -64,9 +64,3 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
-
-## Redis Queue Prefixes
-
-The Redis processor uses a prefix to namespace its keys. The default prefix is `async-job`, and the queue definition name is not added automatically.
-
-The default is sufficient for a single Redis-backed queue. When multiple independent queue definitions share a Redis endpoint, each definition must use a distinct, stable prefix. The Rails and worker processes must use exactly the same prefix for a given queue.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -1,98 +1,142 @@
 # Getting Started
 
-This guide explains how to get started with the `async-job-adapter-active_job` gem.
+This gem connects Rails' Active Job framework to `async-job`. It includes an in-process queue for simple applications and development, and it can use processors such as Redis when jobs need to run in separate worker processes.
 
 ## Installation
 
-Add the gem to your Rails project:
+Add the adapter to your Rails application:
 
-``` bash
+```shell
 $ bundle add async-job-adapter-active_job
 ```
 
-## Core Concepts
+The gem requires Ruby 3.3 or later.
 
-The `async-job-adapter-active_job` gem provides an Active Job adapter for the `async-job` gem. This allows you to use the `async-job` gem with Rails' built-in Active Job framework.
+## Quick Start
 
-- The {ruby Async::Job::ActiveJob::Dispatcher} class manages zero or more queues.
-- The {ruby Async::Job::ActiveJob::Railtie} class provides a convenient interface for configuring the integration.
+Configure Active Job to use the adapter in `config/application.rb`:
 
-In general, `Async::Job` has a concept of queues, where jobs enter into a queue, may get serialized to a queue, then deserialized and processed. This ActiveJob adapter provides {ruby Async::Job::ActiveJob::Interface} which goes at the head of the queue, and matches the interface that ActiveJob expects for enqueueing jobs. At the tail of the queue, the {ruby Async::Job::ActiveJob::Executor} class is responsible for processing jobs by dispatching back into ActiveJob.
-
-## Usage
-
-In order to use `Async::Job`, you need to define your queues and configure the Active Job adapter. Here is an example configuration:
-
-### `ActiveJob` Queue Adapter Configuration
-
-You can configure the ActiveJob queue adapter globally (in `config/application.rb`) or per-environment (in `config/environments/*.rb`).
-
-```
-# In config/application.rb or config/environments/*.rb
-
-config.active_job.queue_adapter = :async_job
+```ruby
+module MyApplication
+	class Application < Rails::Application
+		config.active_job.queue_adapter = :async_job
+	end
+end
 ```
 
-### `Async::Job` Queue Configuration
+Create an Active Job as usual:
 
-You can define your queues in an initializer file (e.g., `config/initializers/async_job.rb`). Here is an example configuration that sets up two queues: a default queue using Redis and a local queue that processes jobs inline. NOTE that inline jobs will run **sequentially** (that is, not concurrently) outside of an `Async` event loop (that is to say, your jobs will block unless you're running your server using falcon).
+```ruby
+class GreetingJob < ApplicationJob
+	queue_as :default
 
-``` ruby
-# config/initializers/async_job.rb
+	def perform(name)
+		Rails.logger.info("Hello, #{name}!")
+	end
+end
+```
 
+Enqueue it with `perform_later`:
+
+```ruby
+GreetingJob.perform_later("World")
+```
+
+That is enough for a working setup. The adapter provides a `default` queue backed by {ruby Async::Job::Processor::Inline}, so it does not need Redis or a separate worker.
+
+The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
+
+## Using Redis and a Separate Worker
+
+Use a persistent processor when jobs must outlive the web process or run on separate machines. Redis support is provided by a separate gem:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
+
+```ruby
 require "async/job/processor/redis"
-require "async/job/processor/inline"
 
 Rails.application.configure do
-	# Create a queue for the "default" backend:
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis
-	end
-	
-	# Create a queue named "local" which uses the Inline backend:
-	config.async_job.define_queue "local" do
-		dequeue Async::Job::Processor::Inline
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
 	end
 end
 ```
 
-#### Job Specific Configuration
+The Redis processor connects to Redis on the local default endpoint unless you pass it another endpoint. Use an application-, environment-, and queue-specific prefix to keep unrelated jobs separate. See the `async-job-processor-redis` documentation for connection and processor options.
 
-Rather than using `Async::Job` for all jobs, you could opt in using a specific queue adapter for a specific job. Here is an example:
+Start a worker from the root of the Rails application so it can load `config/environment.rb`:
 
-``` ruby
-class MyJob < ApplicationJob
+```shell
+$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+By default, the worker starts every defined queue. To start only selected queues, provide a comma-separated list of definition names:
+
+```shell
+$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
+```
+
+If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
+
+An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement.
+
+## Defining Multiple Queues
+
+Every queue name used by an Active Job must have a matching definition or alias. For example:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+
+	config.async_job.define_queue "critical" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+	end
+
+	config.async_job.alias_queue "default", "mailers"
+end
+```
+
+Jobs can then select a queue using the standard Active Job API:
+
+```ruby
+class BillingJob < ApplicationJob
+	queue_as :critical
+
+	def perform(account_id)
+		# ...
+	end
+end
+```
+
+Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
+
+## Opting In One Job at a Time
+
+You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
+
+```ruby
+class GreetingJob < ApplicationJob
 	self.queue_adapter = :async_job
-	queue_as :local
-	
-	# ...
-end
-```
-
-### Running A Server
-
-If you are using a queue that requires a server (e.g. Redis), you will need to run a server. A simple server is provided `async-job-adapter-active_job-server`, which by default will run all define queues.
-
-``` bash
-$ bundle exec async-job-adapter-active_job-server
-```
-
-You can specify different queues using the `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` environment variable.
-
-Alternatively, you may prefer to run your own service. See the code in `bin/async-job-adapter-active_job-server` for an example of how to run a server using a service definition.
-
-### Enqueuing Jobs
-
-To enqueue a job, you can use the `perform_later` method in your Active Job class. Here is an example:
-
-``` ruby
-class MyJob < ApplicationJob
 	queue_as :default
-	
-	def perform(message)
-		puts message
+
+	def perform(name)
+		Rails.logger.info("Hello, #{name}!")
 	end
 end
-
-MyJob.perform_later("Hello, world!")
 ```
+
+Queue definitions are still configured through `config.async_job` in the same way.
+
+## How It Fits Together
+
+When `perform_later` is called, {ruby ActiveJob::QueueAdapters::AsyncJobAdapter} serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, {ruby Async::Job::Adapter::ActiveJob::Executor} deserializes it and invokes Active Job.
+
+Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -10,8 +10,6 @@ Add the adapter to your Rails application:
 $ bundle add async-job-adapter-active_job
 ```
 
-The gem requires Ruby 3.3 or later.
-
 ## Core Concepts
 
 The adapter connects Active Job's standard API to an `async-job` processing pipeline:

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -64,3 +64,9 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
+
+## Redis Queue Prefixes
+
+The Redis processor uses a prefix to namespace its keys. The default prefix is `async-job`, and the queue definition name is not added automatically.
+
+The default is sufficient for a single Redis-backed queue. When multiple independent queue definitions share a Redis endpoint, each definition must use a distinct, stable prefix. The Rails and worker processes must use exactly the same prefix for a given queue.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -64,8 +64,3 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
-
-## Next Steps
-
-- [Production Deployment](../production-deployment/index) explains how to move jobs into a shared Redis queue and run separate worker processes.
-- [Queue Configuration](../queue-configuration/index) explains queue definitions, aliases, multiple queues, and per-job adoption.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This gem connects Rails' Active Job framework to `async-job`. It includes an in-process queue for simple applications and development, and it can use processors such as Redis when jobs need to run in separate worker processes.
+This guide explains how to use `async-job-adapter-active_job` to run Rails Active Job workloads with inline or Redis-backed queues.
 
 ## Installation
 
@@ -12,7 +12,20 @@ $ bundle add async-job-adapter-active_job
 
 The gem requires Ruby 3.3 or later.
 
+## Core Concepts
+
+The adapter connects Active Job's standard API to an `async-job` processing pipeline:
+
+- ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` receives jobs from `perform_later` and dispatches their serialized payloads.
+- A queue definition maps an Active Job queue name to an `async-job` processor.
+- The processor determines where jobs wait and run. The built-in inline processor keeps work in the application process, while processors such as Redis support separate workers.
+- ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes queued payloads and invokes Active Job.
+
+Active Job remains responsible for arguments, callbacks, retries, and error handling. This gem supplies the queue adapter and worker integration.
+
 ## Quick Start
+
+The built-in inline queue is the quickest way to get started because it does not require Redis or a separate worker. It is useful during development and for non-critical work that can remain in the application process.
 
 Configure Active Job to use the adapter in `config/application.rb`:
 
@@ -24,14 +37,16 @@ module MyApplication
 end
 ```
 
-Create an Active Job as usual:
+Create an Active Job as usual. Define retry and discard behavior on the job so expected failures are handled explicitly:
 
 ```ruby
-class GreetingJob < ApplicationJob
+class SearchIndexRefreshJob < ApplicationJob
 	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
 
-	def perform(name)
-		Rails.logger.info("Hello, #{name}!")
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
 	end
 end
 ```
@@ -39,16 +54,28 @@ end
 Enqueue it with `perform_later`:
 
 ```ruby
-GreetingJob.perform_later("World")
+SearchIndexRefreshJob.perform_later(product.id)
 ```
 
-That is enough for a working setup. The adapter provides a `default` queue backed by {ruby Async::Job::Processor::Inline}, so it does not need Redis or a separate worker.
+Scheduled jobs use the standard Active Job API too:
+
+```ruby
+SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
+```
+
+That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
 
 ## Using Redis and a Separate Worker
 
-Use a persistent processor when jobs must outlive the web process or run on separate machines. Redis support is provided by a separate gem:
+Web processes are frequently restarted or scaled independently, so important jobs need a shared queue. Use a Redis-backed queue when jobs must:
+
+- Survive a web process restart.
+- Run outside the request-serving process.
+- Be consumed by workers on separate machines.
+
+Redis support is provided by a separate gem:
 
 ```shell
 $ bundle add async-job-processor-redis
@@ -82,11 +109,13 @@ $ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-jo
 
 If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
 
-An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement.
+An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement. Conversely, keep the inline queue when process restarts and separate worker capacity are not concerns.
 
 ## Defining Multiple Queues
 
-Every queue name used by an Active Job must have a matching definition or alias. For example:
+Multiple queue definitions let you isolate latency-sensitive jobs from slower bulk work and assign them to different worker groups. Every queue name used by an Active Job must have a matching definition or alias.
+
+For example, define a dedicated queue for critical billing work while routing Rails' `mailers` queue through the default processor:
 
 ```ruby
 require "async/job/processor/redis"
@@ -107,28 +136,32 @@ end
 Jobs can then select a queue using the standard Active Job API:
 
 ```ruby
-class BillingJob < ApplicationJob
+class PaymentCaptureJob < ApplicationJob
 	queue_as :critical
 
-	def perform(account_id)
-		# ...
+	def perform(payment_id)
+		Payment.find(payment_id).capture!
 	end
 end
 ```
 
 Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
 
+Prefer an alias when jobs only need another Active Job queue name. Create a separate definition, Redis prefix, and worker group when the workload needs genuine isolation.
+
 ## Opting In One Job at a Time
 
 You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
 
 ```ruby
-class GreetingJob < ApplicationJob
+class SearchIndexRefreshJob < ApplicationJob
 	self.queue_adapter = :async_job
 	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
 
-	def perform(name)
-		Rails.logger.info("Hello, #{name}!")
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
 	end
 end
 ```
@@ -137,6 +170,28 @@ Queue definitions are still configured through `config.async_job` in the same wa
 
 ## How It Fits Together
 
-When `perform_later` is called, {ruby ActiveJob::QueueAdapters::AsyncJobAdapter} serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, {ruby Async::Job::Adapter::ActiveJob::Executor} deserializes it and invokes Active Job.
+When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
 
 Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
+
+## Troubleshooting
+
+### A Queue Name Raises `KeyError`
+
+The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it using `config.async_job.alias_queue`.
+
+### `perform_later` Waits for the Job
+
+The inline processor runs synchronously when there is no active Async event loop. Run Rails with an Async-based server such as Falcon for in-process concurrency, or use Redis and a separate worker for process isolation.
+
+### Jobs Do Not Reach the Worker
+
+Confirm that both the Rails process and worker load the same queue definition, Redis endpoint, prefix, and Rails environment. An inline definition cannot send work to another process.
+
+### The Worker Cannot Load Rails
+
+Run `async-job-adapter-active_job-server` from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
+
+### A Selected Queue Does Not Start
+
+`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts comma-separated definition names, not aliases. Avoid spaces around the names.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -44,7 +44,7 @@ class SearchIndexRefreshJob < ApplicationJob
 	queue_as :default
 	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
 	discard_on ActiveRecord::RecordNotFound
-
+	
 	def perform(product_id)
 		Product.find(product_id).refresh_search_index!
 	end
@@ -67,131 +67,7 @@ That is enough for a working setup. The adapter provides a `default` queue backe
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
 
-## Using Redis and a Separate Worker
+## Next Steps
 
-Web processes are frequently restarted or scaled independently, so important jobs need a shared queue. Use a Redis-backed queue when jobs must:
-
-- Survive a web process restart.
-- Run outside the request-serving process.
-- Be consumed by workers on separate machines.
-
-Redis support is provided by a separate gem:
-
-```shell
-$ bundle add async-job-processor-redis
-```
-
-Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
-
-```ruby
-require "async/job/processor/redis"
-
-Rails.application.configure do
-	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
-	end
-end
-```
-
-The Redis processor connects to Redis on the local default endpoint unless you pass it another endpoint. Use an application-, environment-, and queue-specific prefix to keep unrelated jobs separate. See the `async-job-processor-redis` documentation for connection and processor options.
-
-Start a worker from the root of the Rails application so it can load `config/environment.rb`:
-
-```shell
-$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
-```
-
-By default, the worker starts every defined queue. To start only selected queues, provide a comma-separated list of definition names:
-
-```shell
-$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
-```
-
-If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
-
-An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement. Conversely, keep the inline queue when process restarts and separate worker capacity are not concerns.
-
-## Defining Multiple Queues
-
-Multiple queue definitions let you isolate latency-sensitive jobs from slower bulk work and assign them to different worker groups. Every queue name used by an Active Job must have a matching definition or alias.
-
-For example, define a dedicated queue for critical billing work while routing Rails' `mailers` queue through the default processor:
-
-```ruby
-require "async/job/processor/redis"
-
-Rails.application.configure do
-	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
-	end
-
-	config.async_job.define_queue "critical" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
-	end
-
-	config.async_job.alias_queue "default", "mailers"
-end
-```
-
-Jobs can then select a queue using the standard Active Job API:
-
-```ruby
-class PaymentCaptureJob < ApplicationJob
-	queue_as :critical
-
-	def perform(payment_id)
-		Payment.find(payment_id).capture!
-	end
-end
-```
-
-Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
-
-Prefer an alias when jobs only need another Active Job queue name. Create a separate definition, Redis prefix, and worker group when the workload needs genuine isolation.
-
-## Opting In One Job at a Time
-
-You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
-
-```ruby
-class SearchIndexRefreshJob < ApplicationJob
-	self.queue_adapter = :async_job
-	queue_as :default
-	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
-	discard_on ActiveRecord::RecordNotFound
-
-	def perform(product_id)
-		Product.find(product_id).refresh_search_index!
-	end
-end
-```
-
-Queue definitions are still configured through `config.async_job` in the same way.
-
-## How It Fits Together
-
-When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
-
-Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
-
-## Troubleshooting
-
-### A Queue Name Raises `KeyError`
-
-The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it using `config.async_job.alias_queue`.
-
-### `perform_later` Waits for the Job
-
-The inline processor runs synchronously when there is no active Async event loop. Run Rails with an Async-based server such as Falcon for in-process concurrency, or use Redis and a separate worker for process isolation.
-
-### Jobs Do Not Reach the Worker
-
-Confirm that both the Rails process and worker load the same queue definition, Redis endpoint, prefix, and Rails environment. An inline definition cannot send work to another process.
-
-### The Worker Cannot Load Rails
-
-Run `async-job-adapter-active_job-server` from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
-
-### A Selected Queue Does Not Start
-
-`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts comma-separated definition names, not aliases. Avoid spaces around the names.
+- [Production Deployment](../production-deployment/index) explains how to move jobs into a shared Redis queue and run separate worker processes.
+- [Queue Configuration](../queue-configuration/index) explains queue definitions, aliases, multiple queues, and per-job adoption.

--- a/context/index.yaml
+++ b/context/index.yaml
@@ -8,5 +8,13 @@ metadata:
 files:
 - path: getting-started.md
   title: Getting Started
-  description: This guide explains how to get started with the `async-job-adapter-active_job`
-    gem.
+  description: This guide explains how to use `async-job-adapter-active_job` to run
+    Rails Active Job workloads with inline or Redis-backed queues.
+- path: production-deployment.md
+  title: Production Deployment
+  description: This guide explains how to deploy `async-job-adapter-active_job` with
+    Redis-backed queues and separate worker processes.
+- path: queue-configuration.md
+  title: Queue Configuration
+  description: This guide explains how to configure `async-job` queue definitions,
+    route Active Jobs, and adopt the adapter incrementally.

--- a/context/production-deployment.md
+++ b/context/production-deployment.md
@@ -77,21 +77,3 @@ Before sending production traffic, confirm that:
 - Redis persistence and availability match the durability requirements of the application.
 
 An inline definition cannot transfer jobs into another process. If a job runs in the web process or never appears in Redis, confirm that the Rails process actually replaced the built-in inline definition.
-
-## Troubleshooting
-
-### Jobs Do Not Reach the Worker
-
-Confirm that both process types load the same definition, Redis endpoint, prefix, and Rails environment. Also verify that the job's `queue_as` value resolves to that definition.
-
-### The Worker Cannot Load Rails
-
-Run the command from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
-
-### A Selected Queue Does Not Start
-
-Check that `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` contains comma-separated definition names without spaces. An alias is not a worker target.
-
-### `perform_later` Still Waits for the Job
-
-The Rails process is still using the inline definition. Ensure the Redis initializer loads in that environment and replaces `default`, then restart the process.

--- a/context/production-deployment.md
+++ b/context/production-deployment.md
@@ -33,12 +33,12 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis
 	end
 end
 ```
 
-The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
+The processor connects to Redis on its local default endpoint unless another endpoint is provided. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
 
 ## Starting Workers
 

--- a/context/production-deployment.md
+++ b/context/production-deployment.md
@@ -40,8 +40,6 @@ end
 
 The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
 
-See [Queue Configuration](../queue-configuration/index) for multiple definitions, aliases, and per-job routing.
-
 ## Starting Workers
 
 Run the bundled worker from the Rails application root so it can load `config/environment.rb`:

--- a/context/production-deployment.md
+++ b/context/production-deployment.md
@@ -1,0 +1,99 @@
+# Production Deployment
+
+This guide explains how to deploy `async-job-adapter-active_job` with Redis-backed queues and separate worker processes.
+
+## Overview
+
+The built-in inline processor keeps jobs inside the Rails process. That is convenient for development, but jobs cannot survive a process restart or be consumed by another machine.
+
+Use a shared queue and separate workers when jobs must:
+
+- Survive web process restarts.
+- Run outside request-serving processes.
+- Be distributed across one or more worker machines.
+
+Keep the inline processor when those operational guarantees are unnecessary; it has fewer moving parts and requires no external service.
+
+## Installing the Redis Processor
+
+Redis support is provided by a separate gem:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+Ensure a Redis service is available to both the Rails and worker processes.
+
+## Configuring the Queue
+
+Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+end
+```
+
+The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
+
+See [Queue Configuration](../queue-configuration/index) for multiple definitions, aliases, and per-job routing.
+
+## Starting Workers
+
+Run the bundled worker from the Rails application root so it can load `config/environment.rb`:
+
+```shell
+$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+The server loads the Rails environment and starts every defined queue. The service container supervises worker instances and reports their readiness.
+
+If the command cannot run from the application root, set `RAILS_ROOT` explicitly:
+
+```shell
+$ RAILS_ROOT=/srv/my-application RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+## Selecting Queues
+
+Worker groups can listen to a subset of definitions. Provide their names as a comma-separated list:
+
+```shell
+$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
+```
+
+The values must be definition names, not aliases, and should not contain spaces. Run at least one worker group for every Redis-backed definition that should make progress.
+
+## Deployment Checklist
+
+Before sending production traffic, confirm that:
+
+- Rails and workers deploy the same application code and queue configuration.
+- Both process types use the same `RAILS_ENV`, Redis endpoint, and queue prefixes.
+- Each required queue definition has an active worker group.
+- Jobs define appropriate Active Job retry and discard behavior for expected failures.
+- Redis persistence and availability match the durability requirements of the application.
+
+An inline definition cannot transfer jobs into another process. If a job runs in the web process or never appears in Redis, confirm that the Rails process actually replaced the built-in inline definition.
+
+## Troubleshooting
+
+### Jobs Do Not Reach the Worker
+
+Confirm that both process types load the same definition, Redis endpoint, prefix, and Rails environment. Also verify that the job's `queue_as` value resolves to that definition.
+
+### The Worker Cannot Load Rails
+
+Run the command from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
+
+### A Selected Queue Does Not Start
+
+Check that `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` contains comma-separated definition names without spaces. An alias is not a worker target.
+
+### `perform_later` Still Waits for the Job
+
+The Rails process is still using the inline definition. Ensure the Redis initializer loads in that environment and replaces `default`, then restart the process.

--- a/context/queue-configuration.md
+++ b/context/queue-configuration.md
@@ -29,12 +29,24 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis
 	end
 end
 ```
 
-Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
+Processors can accept positional and keyword arguments after the processor class.
+
+## Redis Prefixes
+
+Without an explicit `prefix`, every Redis processor uses `async-job`. Queue definition names do not alter that default, so two definitions using the same Redis endpoint and prefix operate on the same underlying queue.
+
+For each independently processed queue, the prefix must be:
+
+- Distinct from other queues using the same Redis endpoint.
+- Identical in Rails and worker processes.
+- Stable across deployments so existing jobs remain reachable.
+
+Include an application or environment namespace only when those workloads share a Redis endpoint.
 
 ## Defining Multiple Queues
 
@@ -45,11 +57,11 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis, prefix: "async-job:default"
 	end
 	
 	config.async_job.define_queue "critical" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+		dequeue Async::Job::Processor::Redis, prefix: "async-job:critical"
 	end
 end
 ```

--- a/context/queue-configuration.md
+++ b/context/queue-configuration.md
@@ -1,0 +1,124 @@
+# Queue Configuration
+
+This guide explains how to configure `async-job` queue definitions, route Active Jobs, and adopt the adapter incrementally.
+
+## Overview
+
+Active Job assigns every job a queue name. The adapter must map that name to an `async-job` queue definition, which specifies the processor responsible for storing and running the job.
+
+The adapter includes a `default` definition backed by ruby:`Async::Job::Processor::Inline`. Define additional queues when you need:
+
+- A shared processor such as Redis instead of in-process execution.
+- Separate capacity for latency-sensitive and bulk workloads.
+- Several Active Job queue names routed through one processor.
+
+Every name selected by `queue_as` must have a matching definition or alias.
+
+## Defining a Queue
+
+Queue definitions belong in `config/initializers/async_job.rb`. The examples below use the Redis processor so independently operated queues have shared storage:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+This definition replaces the built-in inline `default` queue:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+end
+```
+
+Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
+
+The Redis processor comes from the separate `async-job-processor-redis` gem. See [Production Deployment](../production-deployment/index) for installation and worker operation.
+
+## Defining Multiple Queues
+
+Multiple definitions allow independent worker groups to process different workloads. For example, payment capture can use a dedicated queue while ordinary work remains on `default`:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+	
+	config.async_job.define_queue "critical" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+	end
+end
+```
+
+Select the definition using the standard Active Job API:
+
+```ruby
+class PaymentCaptureJob < ApplicationJob
+	queue_as :critical
+	retry_on PaymentGateway::Unavailable, wait: 5.seconds, attempts: 5
+	discard_on ActiveRecord::RecordNotFound
+	
+	def perform(payment_id)
+		Payment.find(payment_id).capture!
+	end
+end
+```
+
+Create separate definitions only when workloads need distinct storage, capacity, or operational controls. A single definition is simpler when those differences do not matter.
+
+## Aliasing Queue Names
+
+Aliases route several Active Job queue names through one queue definition. This is useful for framework-defined names such as `mailers` when they do not need independent worker capacity:
+
+```ruby
+Rails.application.configure do
+	config.async_job.alias_queue "default", "mailers", "low_priority"
+end
+```
+
+Jobs assigned to `mailers` or `low_priority` are submitted through the `default` definition. Aliases do not create queues and are not valid values for `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES`; worker selection uses definition names.
+
+## Opting In One Job at a Time
+
+Applications can adopt the adapter without replacing their global Active Job backend. Set `queue_adapter` on an individual job and leave other jobs unchanged:
+
+```ruby
+class SearchIndexRefreshJob < ApplicationJob
+	self.queue_adapter = :async_job
+	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
+	
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
+	end
+end
+```
+
+The selected queue must still have a definition or alias in `config.async_job`.
+
+## Understanding the Pipeline
+
+When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the definition selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
+
+Definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of the pipeline; it still supplies the client used by Rails to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
+
+## Common Pitfalls
+
+### A Queue Name Raises `KeyError`
+
+The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it with `config.async_job.alias_queue`.
+
+### Separate Definitions Consume the Same Jobs
+
+Redis definitions with the same endpoint and prefix share the same underlying queue. Assign a distinct prefix to every independently processed definition.
+
+### A Worker Selection Uses an Alias
+
+`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts definition names, not aliases. Select `default`, for example, rather than an alias such as `mailers`.

--- a/context/queue-configuration.md
+++ b/context/queue-configuration.md
@@ -106,17 +106,3 @@ The selected queue must still have a definition or alias in `config.async_job`.
 When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the definition selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
 
 Definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of the pipeline; it still supplies the client used by Rails to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
-
-## Common Pitfalls
-
-### A Queue Name Raises `KeyError`
-
-The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it with `config.async_job.alias_queue`.
-
-### Separate Definitions Consume the Same Jobs
-
-Redis definitions with the same endpoint and prefix share the same underlying queue. Assign a distinct prefix to every independently processed definition.
-
-### A Worker Selection Uses an Alias
-
-`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts definition names, not aliases. Select `default`, for example, rather than an alias such as `mailers`.

--- a/context/queue-configuration.md
+++ b/context/queue-configuration.md
@@ -36,8 +36,6 @@ end
 
 Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
 
-The Redis processor comes from the separate `async-job-processor-redis` gem. See [Production Deployment](../production-deployment/index) for installation and worker operation.
-
 ## Defining Multiple Queues
 
 Multiple definitions allow independent worker groups to process different workloads. For example, payment capture can use a dedicated queue while ordinary work remains on `default`:

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -64,9 +64,3 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
-
-## Redis Queue Prefixes
-
-The Redis processor uses a prefix to namespace its keys. The default prefix is `async-job`, and the queue definition name is not added automatically.
-
-The default is sufficient for a single Redis-backed queue. When multiple independent queue definitions share a Redis endpoint, each definition must use a distinct, stable prefix. The Rails and worker processes must use exactly the same prefix for a given queue.

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -1,98 +1,142 @@
 # Getting Started
 
-This guide explains how to get started with the `async-job-adapter-active_job` gem.
+This gem connects Rails' Active Job framework to `async-job`. It includes an in-process queue for simple applications and development, and it can use processors such as Redis when jobs need to run in separate worker processes.
 
 ## Installation
 
-Add the gem to your Rails project:
+Add the adapter to your Rails application:
 
-``` bash
+```shell
 $ bundle add async-job-adapter-active_job
 ```
 
-## Core Concepts
+The gem requires Ruby 3.3 or later.
 
-The `async-job-adapter-active_job` gem provides an Active Job adapter for the `async-job` gem. This allows you to use the `async-job` gem with Rails' built-in Active Job framework.
+## Quick Start
 
-- The {ruby Async::Job::ActiveJob::Dispatcher} class manages zero or more queues.
-- The {ruby Async::Job::ActiveJob::Railtie} class provides a convenient interface for configuring the integration.
+Configure Active Job to use the adapter in `config/application.rb`:
 
-In general, `Async::Job` has a concept of queues, where jobs enter into a queue, may get serialized to a queue, then deserialized and processed. This ActiveJob adapter provides {ruby Async::Job::ActiveJob::Interface} which goes at the head of the queue, and matches the interface that ActiveJob expects for enqueueing jobs. At the tail of the queue, the {ruby Async::Job::ActiveJob::Executor} class is responsible for processing jobs by dispatching back into ActiveJob.
-
-## Usage
-
-In order to use `Async::Job`, you need to define your queues and configure the Active Job adapter. Here is an example configuration:
-
-### `ActiveJob` Queue Adapter Configuration
-
-You can configure the ActiveJob queue adapter globally (in `config/application.rb`) or per-environment (in `config/environments/*.rb`).
-
-```
-# In config/application.rb or config/environments/*.rb
-
-config.active_job.queue_adapter = :async_job
+```ruby
+module MyApplication
+	class Application < Rails::Application
+		config.active_job.queue_adapter = :async_job
+	end
+end
 ```
 
-### `Async::Job` Queue Configuration
+Create an Active Job as usual:
 
-You can define your queues in an initializer file (e.g., `config/initializers/async_job.rb`). Here is an example configuration that sets up two queues: a default queue using Redis and a local queue that processes jobs inline. NOTE that inline jobs will run **sequentially** (that is, not concurrently) outside of an `Async` event loop (that is to say, your jobs will block unless you're running your server using falcon).
+```ruby
+class GreetingJob < ApplicationJob
+	queue_as :default
 
-``` ruby
-# config/initializers/async_job.rb
+	def perform(name)
+		Rails.logger.info("Hello, #{name}!")
+	end
+end
+```
 
+Enqueue it with `perform_later`:
+
+```ruby
+GreetingJob.perform_later("World")
+```
+
+That is enough for a working setup. The adapter provides a `default` queue backed by {ruby Async::Job::Processor::Inline}, so it does not need Redis or a separate worker.
+
+The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
+
+## Using Redis and a Separate Worker
+
+Use a persistent processor when jobs must outlive the web process or run on separate machines. Redis support is provided by a separate gem:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
+
+```ruby
 require "async/job/processor/redis"
-require "async/job/processor/inline"
 
 Rails.application.configure do
-	# Create a queue for the "default" backend:
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis
-	end
-	
-	# Create a queue named "local" which uses the Inline backend:
-	config.async_job.define_queue "local" do
-		dequeue Async::Job::Processor::Inline
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
 	end
 end
 ```
 
-#### Job Specific Configuration
+The Redis processor connects to Redis on the local default endpoint unless you pass it another endpoint. Use an application-, environment-, and queue-specific prefix to keep unrelated jobs separate. See the `async-job-processor-redis` documentation for connection and processor options.
 
-Rather than using `Async::Job` for all jobs, you could opt in using a specific queue adapter for a specific job. Here is an example:
+Start a worker from the root of the Rails application so it can load `config/environment.rb`:
 
-``` ruby
-class MyJob < ApplicationJob
+```shell
+$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+By default, the worker starts every defined queue. To start only selected queues, provide a comma-separated list of definition names:
+
+```shell
+$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
+```
+
+If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
+
+An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement.
+
+## Defining Multiple Queues
+
+Every queue name used by an Active Job must have a matching definition or alias. For example:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+
+	config.async_job.define_queue "critical" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+	end
+
+	config.async_job.alias_queue "default", "mailers"
+end
+```
+
+Jobs can then select a queue using the standard Active Job API:
+
+```ruby
+class BillingJob < ApplicationJob
+	queue_as :critical
+
+	def perform(account_id)
+		# ...
+	end
+end
+```
+
+Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
+
+## Opting In One Job at a Time
+
+You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
+
+```ruby
+class GreetingJob < ApplicationJob
 	self.queue_adapter = :async_job
-	queue_as :local
-	
-	# ...
-end
-```
-
-### Running A Server
-
-If you are using a queue that requires a server (e.g. Redis), you will need to run a server. A simple server is provided `async-job-adapter-active_job-server`, which by default will run all define queues.
-
-``` bash
-$ bundle exec async-job-adapter-active_job-server
-```
-
-You can specify different queues using the `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` environment variable.
-
-Alternatively, you may prefer to run your own service. See the code in `bin/async-job-adapter-active_job-server` for an example of how to run a server using a service definition.
-
-### Enqueuing Jobs
-
-To enqueue a job, you can use the `perform_later` method in your Active Job class. Here is an example:
-
-``` ruby
-class MyJob < ApplicationJob
 	queue_as :default
-	
-	def perform(message)
-		puts message
+
+	def perform(name)
+		Rails.logger.info("Hello, #{name}!")
 	end
 end
-
-MyJob.perform_later("Hello, world!")
 ```
+
+Queue definitions are still configured through `config.async_job` in the same way.
+
+## How It Fits Together
+
+When `perform_later` is called, {ruby ActiveJob::QueueAdapters::AsyncJobAdapter} serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, {ruby Async::Job::Adapter::ActiveJob::Executor} deserializes it and invokes Active Job.
+
+Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -10,8 +10,6 @@ Add the adapter to your Rails application:
 $ bundle add async-job-adapter-active_job
 ```
 
-The gem requires Ruby 3.3 or later.
-
 ## Core Concepts
 
 The adapter connects Active Job's standard API to an `async-job` processing pipeline:

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -64,3 +64,9 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
+
+## Redis Queue Prefixes
+
+The Redis processor uses a prefix to namespace its keys. The default prefix is `async-job`, and the queue definition name is not added automatically.
+
+The default is sufficient for a single Redis-backed queue. When multiple independent queue definitions share a Redis endpoint, each definition must use a distinct, stable prefix. The Rails and worker processes must use exactly the same prefix for a given queue.

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -64,8 +64,3 @@ SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
 That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
-
-## Next Steps
-
-- [Production Deployment](../production-deployment/index) explains how to move jobs into a shared Redis queue and run separate worker processes.
-- [Queue Configuration](../queue-configuration/index) explains queue definitions, aliases, multiple queues, and per-job adoption.

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This gem connects Rails' Active Job framework to `async-job`. It includes an in-process queue for simple applications and development, and it can use processors such as Redis when jobs need to run in separate worker processes.
+This guide explains how to use `async-job-adapter-active_job` to run Rails Active Job workloads with inline or Redis-backed queues.
 
 ## Installation
 
@@ -12,7 +12,20 @@ $ bundle add async-job-adapter-active_job
 
 The gem requires Ruby 3.3 or later.
 
+## Core Concepts
+
+The adapter connects Active Job's standard API to an `async-job` processing pipeline:
+
+- ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` receives jobs from `perform_later` and dispatches their serialized payloads.
+- A queue definition maps an Active Job queue name to an `async-job` processor.
+- The processor determines where jobs wait and run. The built-in inline processor keeps work in the application process, while processors such as Redis support separate workers.
+- ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes queued payloads and invokes Active Job.
+
+Active Job remains responsible for arguments, callbacks, retries, and error handling. This gem supplies the queue adapter and worker integration.
+
 ## Quick Start
+
+The built-in inline queue is the quickest way to get started because it does not require Redis or a separate worker. It is useful during development and for non-critical work that can remain in the application process.
 
 Configure Active Job to use the adapter in `config/application.rb`:
 
@@ -24,14 +37,16 @@ module MyApplication
 end
 ```
 
-Create an Active Job as usual:
+Create an Active Job as usual. Define retry and discard behavior on the job so expected failures are handled explicitly:
 
 ```ruby
-class GreetingJob < ApplicationJob
+class SearchIndexRefreshJob < ApplicationJob
 	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
 
-	def perform(name)
-		Rails.logger.info("Hello, #{name}!")
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
 	end
 end
 ```
@@ -39,16 +54,28 @@ end
 Enqueue it with `perform_later`:
 
 ```ruby
-GreetingJob.perform_later("World")
+SearchIndexRefreshJob.perform_later(product.id)
 ```
 
-That is enough for a working setup. The adapter provides a `default` queue backed by {ruby Async::Job::Processor::Inline}, so it does not need Redis or a separate worker.
+Scheduled jobs use the standard Active Job API too:
+
+```ruby
+SearchIndexRefreshJob.set(wait: 5.minutes).perform_later(product.id)
+```
+
+That is enough for a working setup. The adapter provides a `default` queue backed by ruby:`Async::Job::Processor::Inline`.
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
 
 ## Using Redis and a Separate Worker
 
-Use a persistent processor when jobs must outlive the web process or run on separate machines. Redis support is provided by a separate gem:
+Web processes are frequently restarted or scaled independently, so important jobs need a shared queue. Use a Redis-backed queue when jobs must:
+
+- Survive a web process restart.
+- Run outside the request-serving process.
+- Be consumed by workers on separate machines.
+
+Redis support is provided by a separate gem:
 
 ```shell
 $ bundle add async-job-processor-redis
@@ -82,11 +109,13 @@ $ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-jo
 
 If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
 
-An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement.
+An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement. Conversely, keep the inline queue when process restarts and separate worker capacity are not concerns.
 
 ## Defining Multiple Queues
 
-Every queue name used by an Active Job must have a matching definition or alias. For example:
+Multiple queue definitions let you isolate latency-sensitive jobs from slower bulk work and assign them to different worker groups. Every queue name used by an Active Job must have a matching definition or alias.
+
+For example, define a dedicated queue for critical billing work while routing Rails' `mailers` queue through the default processor:
 
 ```ruby
 require "async/job/processor/redis"
@@ -107,28 +136,32 @@ end
 Jobs can then select a queue using the standard Active Job API:
 
 ```ruby
-class BillingJob < ApplicationJob
+class PaymentCaptureJob < ApplicationJob
 	queue_as :critical
 
-	def perform(account_id)
-		# ...
+	def perform(payment_id)
+		Payment.find(payment_id).capture!
 	end
 end
 ```
 
 Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
 
+Prefer an alias when jobs only need another Active Job queue name. Create a separate definition, Redis prefix, and worker group when the workload needs genuine isolation.
+
 ## Opting In One Job at a Time
 
 You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
 
 ```ruby
-class GreetingJob < ApplicationJob
+class SearchIndexRefreshJob < ApplicationJob
 	self.queue_adapter = :async_job
 	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
 
-	def perform(name)
-		Rails.logger.info("Hello, #{name}!")
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
 	end
 end
 ```
@@ -137,6 +170,28 @@ Queue definitions are still configured through `config.async_job` in the same wa
 
 ## How It Fits Together
 
-When `perform_later` is called, {ruby ActiveJob::QueueAdapters::AsyncJobAdapter} serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, {ruby Async::Job::Adapter::ActiveJob::Executor} deserializes it and invokes Active Job.
+When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
 
 Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
+
+## Troubleshooting
+
+### A Queue Name Raises `KeyError`
+
+The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it using `config.async_job.alias_queue`.
+
+### `perform_later` Waits for the Job
+
+The inline processor runs synchronously when there is no active Async event loop. Run Rails with an Async-based server such as Falcon for in-process concurrency, or use Redis and a separate worker for process isolation.
+
+### Jobs Do Not Reach the Worker
+
+Confirm that both the Rails process and worker load the same queue definition, Redis endpoint, prefix, and Rails environment. An inline definition cannot send work to another process.
+
+### The Worker Cannot Load Rails
+
+Run `async-job-adapter-active_job-server` from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
+
+### A Selected Queue Does Not Start
+
+`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts comma-separated definition names, not aliases. Avoid spaces around the names.

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -44,7 +44,7 @@ class SearchIndexRefreshJob < ApplicationJob
 	queue_as :default
 	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
 	discard_on ActiveRecord::RecordNotFound
-
+	
 	def perform(product_id)
 		Product.find(product_id).refresh_search_index!
 	end
@@ -67,131 +67,7 @@ That is enough for a working setup. The adapter provides a `default` queue backe
 
 The inline processor is intentionally simple: jobs remain in the application process and will not survive a restart. Inside an Async event loop, such as a Rails application served by Falcon, jobs can run concurrently in background tasks. Outside an Async event loop, `perform_later` waits for the job to finish before returning.
 
-## Using Redis and a Separate Worker
+## Next Steps
 
-Web processes are frequently restarted or scaled independently, so important jobs need a shared queue. Use a Redis-backed queue when jobs must:
-
-- Survive a web process restart.
-- Run outside the request-serving process.
-- Be consumed by workers on separate machines.
-
-Redis support is provided by a separate gem:
-
-```shell
-$ bundle add async-job-processor-redis
-```
-
-Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
-
-```ruby
-require "async/job/processor/redis"
-
-Rails.application.configure do
-	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
-	end
-end
-```
-
-The Redis processor connects to Redis on the local default endpoint unless you pass it another endpoint. Use an application-, environment-, and queue-specific prefix to keep unrelated jobs separate. See the `async-job-processor-redis` documentation for connection and processor options.
-
-Start a worker from the root of the Rails application so it can load `config/environment.rb`:
-
-```shell
-$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
-```
-
-By default, the worker starts every defined queue. To start only selected queues, provide a comma-separated list of definition names:
-
-```shell
-$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
-```
-
-If the command is not run from the Rails application root, set `RAILS_ROOT` explicitly.
-
-An inline queue is local to the process that enqueues the job. Starting a separate worker for an inline queue does not move those jobs into that worker; use a shared processor such as Redis for that arrangement. Conversely, keep the inline queue when process restarts and separate worker capacity are not concerns.
-
-## Defining Multiple Queues
-
-Multiple queue definitions let you isolate latency-sensitive jobs from slower bulk work and assign them to different worker groups. Every queue name used by an Active Job must have a matching definition or alias.
-
-For example, define a dedicated queue for critical billing work while routing Rails' `mailers` queue through the default processor:
-
-```ruby
-require "async/job/processor/redis"
-
-Rails.application.configure do
-	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
-	end
-
-	config.async_job.define_queue "critical" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
-	end
-
-	config.async_job.alias_queue "default", "mailers"
-end
-```
-
-Jobs can then select a queue using the standard Active Job API:
-
-```ruby
-class PaymentCaptureJob < ApplicationJob
-	queue_as :critical
-
-	def perform(payment_id)
-		Payment.find(payment_id).capture!
-	end
-end
-```
-
-Aliases route several Active Job queue names through one `async-job` queue definition. Worker selection through `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` uses definition names (`default` and `critical` above), not aliases (`mailers`).
-
-Prefer an alias when jobs only need another Active Job queue name. Create a separate definition, Redis prefix, and worker group when the workload needs genuine isolation.
-
-## Opting In One Job at a Time
-
-You do not need to replace the application's global adapter. To migrate incrementally, configure the adapter on an individual job:
-
-```ruby
-class SearchIndexRefreshJob < ApplicationJob
-	self.queue_adapter = :async_job
-	queue_as :default
-	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
-	discard_on ActiveRecord::RecordNotFound
-
-	def perform(product_id)
-		Product.find(product_id).refresh_search_index!
-	end
-end
-```
-
-Queue definitions are still configured through `config.async_job` in the same way.
-
-## How It Fits Together
-
-When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the `async-job` queue selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
-
-Queue definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of that pipeline; it still provides the client used by the Rails process to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
-
-## Troubleshooting
-
-### A Queue Name Raises `KeyError`
-
-The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it using `config.async_job.alias_queue`.
-
-### `perform_later` Waits for the Job
-
-The inline processor runs synchronously when there is no active Async event loop. Run Rails with an Async-based server such as Falcon for in-process concurrency, or use Redis and a separate worker for process isolation.
-
-### Jobs Do Not Reach the Worker
-
-Confirm that both the Rails process and worker load the same queue definition, Redis endpoint, prefix, and Rails environment. An inline definition cannot send work to another process.
-
-### The Worker Cannot Load Rails
-
-Run `async-job-adapter-active_job-server` from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
-
-### A Selected Queue Does Not Start
-
-`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts comma-separated definition names, not aliases. Avoid spaces around the names.
+- [Production Deployment](../production-deployment/index) explains how to move jobs into a shared Redis queue and run separate worker processes.
+- [Queue Configuration](../queue-configuration/index) explains queue definitions, aliases, multiple queues, and per-job adoption.

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -1,2 +1,8 @@
 getting-started:
   order: 1
+
+production-deployment:
+  order: 2
+
+queue-configuration:
+  order: 3

--- a/guides/production-deployment/readme.md
+++ b/guides/production-deployment/readme.md
@@ -77,21 +77,3 @@ Before sending production traffic, confirm that:
 - Redis persistence and availability match the durability requirements of the application.
 
 An inline definition cannot transfer jobs into another process. If a job runs in the web process or never appears in Redis, confirm that the Rails process actually replaced the built-in inline definition.
-
-## Troubleshooting
-
-### Jobs Do Not Reach the Worker
-
-Confirm that both process types load the same definition, Redis endpoint, prefix, and Rails environment. Also verify that the job's `queue_as` value resolves to that definition.
-
-### The Worker Cannot Load Rails
-
-Run the command from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
-
-### A Selected Queue Does Not Start
-
-Check that `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` contains comma-separated definition names without spaces. An alias is not a worker target.
-
-### `perform_later` Still Waits for the Job
-
-The Rails process is still using the inline definition. Ensure the Redis initializer loads in that environment and replaces `default`, then restart the process.

--- a/guides/production-deployment/readme.md
+++ b/guides/production-deployment/readme.md
@@ -33,12 +33,12 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis
 	end
 end
 ```
 
-The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
+The processor connects to Redis on its local default endpoint unless another endpoint is provided. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
 
 ## Starting Workers
 

--- a/guides/production-deployment/readme.md
+++ b/guides/production-deployment/readme.md
@@ -40,8 +40,6 @@ end
 
 The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
 
-See [Queue Configuration](../queue-configuration/index) for multiple definitions, aliases, and per-job routing.
-
 ## Starting Workers
 
 Run the bundled worker from the Rails application root so it can load `config/environment.rb`:

--- a/guides/production-deployment/readme.md
+++ b/guides/production-deployment/readme.md
@@ -1,0 +1,99 @@
+# Production Deployment
+
+This guide explains how to deploy `async-job-adapter-active_job` with Redis-backed queues and separate worker processes.
+
+## Overview
+
+The built-in inline processor keeps jobs inside the Rails process. That is convenient for development, but jobs cannot survive a process restart or be consumed by another machine.
+
+Use a shared queue and separate workers when jobs must:
+
+- Survive web process restarts.
+- Run outside request-serving processes.
+- Be distributed across one or more worker machines.
+
+Keep the inline processor when those operational guarantees are unnecessary; it has fewer moving parts and requires no external service.
+
+## Installing the Redis Processor
+
+Redis support is provided by a separate gem:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+Ensure a Redis service is available to both the Rails and worker processes.
+
+## Configuring the Queue
+
+Replace the built-in `default` queue definition in `config/initializers/async_job.rb`:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+end
+```
+
+The processor connects to Redis on its local default endpoint unless another endpoint is provided. The Rails process and worker must use the same endpoint and prefix. Use different prefixes for each application, Rails environment, and independently processed queue.
+
+See [Queue Configuration](../queue-configuration/index) for multiple definitions, aliases, and per-job routing.
+
+## Starting Workers
+
+Run the bundled worker from the Rails application root so it can load `config/environment.rb`:
+
+```shell
+$ RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+The server loads the Rails environment and starts every defined queue. The service container supervises worker instances and reports their readiness.
+
+If the command cannot run from the application root, set `RAILS_ROOT` explicitly:
+
+```shell
+$ RAILS_ROOT=/srv/my-application RAILS_ENV=production bundle exec async-job-adapter-active_job-server
+```
+
+## Selecting Queues
+
+Worker groups can listen to a subset of definitions. Provide their names as a comma-separated list:
+
+```shell
+$ ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES=default,critical bundle exec async-job-adapter-active_job-server
+```
+
+The values must be definition names, not aliases, and should not contain spaces. Run at least one worker group for every Redis-backed definition that should make progress.
+
+## Deployment Checklist
+
+Before sending production traffic, confirm that:
+
+- Rails and workers deploy the same application code and queue configuration.
+- Both process types use the same `RAILS_ENV`, Redis endpoint, and queue prefixes.
+- Each required queue definition has an active worker group.
+- Jobs define appropriate Active Job retry and discard behavior for expected failures.
+- Redis persistence and availability match the durability requirements of the application.
+
+An inline definition cannot transfer jobs into another process. If a job runs in the web process or never appears in Redis, confirm that the Rails process actually replaced the built-in inline definition.
+
+## Troubleshooting
+
+### Jobs Do Not Reach the Worker
+
+Confirm that both process types load the same definition, Redis endpoint, prefix, and Rails environment. Also verify that the job's `queue_as` value resolves to that definition.
+
+### The Worker Cannot Load Rails
+
+Run the command from the Rails application root, or set `RAILS_ROOT` to the directory containing `config/environment.rb`.
+
+### A Selected Queue Does Not Start
+
+Check that `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` contains comma-separated definition names without spaces. An alias is not a worker target.
+
+### `perform_later` Still Waits for the Job
+
+The Rails process is still using the inline definition. Ensure the Redis initializer loads in that environment and replaces `default`, then restart the process.

--- a/guides/queue-configuration/readme.md
+++ b/guides/queue-configuration/readme.md
@@ -29,12 +29,24 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis
 	end
 end
 ```
 
-Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
+Processors can accept positional and keyword arguments after the processor class.
+
+## Redis Prefixes
+
+Without an explicit `prefix`, every Redis processor uses `async-job`. Queue definition names do not alter that default, so two definitions using the same Redis endpoint and prefix operate on the same underlying queue.
+
+For each independently processed queue, the prefix must be:
+
+- Distinct from other queues using the same Redis endpoint.
+- Identical in Rails and worker processes.
+- Stable across deployments so existing jobs remain reachable.
+
+Include an application or environment namespace only when those workloads share a Redis endpoint.
 
 ## Defining Multiple Queues
 
@@ -45,11 +57,11 @@ require "async/job/processor/redis"
 
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+		dequeue Async::Job::Processor::Redis, prefix: "async-job:default"
 	end
 	
 	config.async_job.define_queue "critical" do
-		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+		dequeue Async::Job::Processor::Redis, prefix: "async-job:critical"
 	end
 end
 ```

--- a/guides/queue-configuration/readme.md
+++ b/guides/queue-configuration/readme.md
@@ -1,0 +1,124 @@
+# Queue Configuration
+
+This guide explains how to configure `async-job` queue definitions, route Active Jobs, and adopt the adapter incrementally.
+
+## Overview
+
+Active Job assigns every job a queue name. The adapter must map that name to an `async-job` queue definition, which specifies the processor responsible for storing and running the job.
+
+The adapter includes a `default` definition backed by ruby:`Async::Job::Processor::Inline`. Define additional queues when you need:
+
+- A shared processor such as Redis instead of in-process execution.
+- Separate capacity for latency-sensitive and bulk workloads.
+- Several Active Job queue names routed through one processor.
+
+Every name selected by `queue_as` must have a matching definition or alias.
+
+## Defining a Queue
+
+Queue definitions belong in `config/initializers/async_job.rb`. The examples below use the Redis processor so independently operated queues have shared storage:
+
+```shell
+$ bundle add async-job-processor-redis
+```
+
+This definition replaces the built-in inline `default` queue:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+end
+```
+
+Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
+
+The Redis processor comes from the separate `async-job-processor-redis` gem. See [Production Deployment](../production-deployment/index) for installation and worker operation.
+
+## Defining Multiple Queues
+
+Multiple definitions allow independent worker groups to process different workloads. For example, payment capture can use a dedicated queue while ordinary work remains on `default`:
+
+```ruby
+require "async/job/processor/redis"
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:default"
+	end
+	
+	config.async_job.define_queue "critical" do
+		dequeue Async::Job::Processor::Redis, prefix: "my-application:#{Rails.env}:critical"
+	end
+end
+```
+
+Select the definition using the standard Active Job API:
+
+```ruby
+class PaymentCaptureJob < ApplicationJob
+	queue_as :critical
+	retry_on PaymentGateway::Unavailable, wait: 5.seconds, attempts: 5
+	discard_on ActiveRecord::RecordNotFound
+	
+	def perform(payment_id)
+		Payment.find(payment_id).capture!
+	end
+end
+```
+
+Create separate definitions only when workloads need distinct storage, capacity, or operational controls. A single definition is simpler when those differences do not matter.
+
+## Aliasing Queue Names
+
+Aliases route several Active Job queue names through one queue definition. This is useful for framework-defined names such as `mailers` when they do not need independent worker capacity:
+
+```ruby
+Rails.application.configure do
+	config.async_job.alias_queue "default", "mailers", "low_priority"
+end
+```
+
+Jobs assigned to `mailers` or `low_priority` are submitted through the `default` definition. Aliases do not create queues and are not valid values for `ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES`; worker selection uses definition names.
+
+## Opting In One Job at a Time
+
+Applications can adopt the adapter without replacing their global Active Job backend. Set `queue_adapter` on an individual job and leave other jobs unchanged:
+
+```ruby
+class SearchIndexRefreshJob < ApplicationJob
+	self.queue_adapter = :async_job
+	queue_as :default
+	retry_on SearchIndex::Unavailable, wait: 5.seconds, attempts: 3
+	discard_on ActiveRecord::RecordNotFound
+	
+	def perform(product_id)
+		Product.find(product_id).refresh_search_index!
+	end
+end
+```
+
+The selected queue must still have a definition or alias in `config.async_job`.
+
+## Understanding the Pipeline
+
+When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the definition selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
+
+Definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of the pipeline; it still supplies the client used by Rails to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
+
+## Common Pitfalls
+
+### A Queue Name Raises `KeyError`
+
+The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it with `config.async_job.alias_queue`.
+
+### Separate Definitions Consume the Same Jobs
+
+Redis definitions with the same endpoint and prefix share the same underlying queue. Assign a distinct prefix to every independently processed definition.
+
+### A Worker Selection Uses an Alias
+
+`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts definition names, not aliases. Select `default`, for example, rather than an alias such as `mailers`.

--- a/guides/queue-configuration/readme.md
+++ b/guides/queue-configuration/readme.md
@@ -106,17 +106,3 @@ The selected queue must still have a definition or alias in `config.async_job`.
 When `perform_later` is called, ruby:`ActiveJob::QueueAdapters::AsyncJobAdapter` serializes the Active Job and sends it to the definition selected by `queue_as`. The configured processor transports or schedules the payload. On the consumer side, ruby:`Async::Job::Adapter::ActiveJob::Executor` deserializes it and invokes Active Job.
 
 Definitions use `async-job`'s pipeline builder. The processor is written as `dequeue` because it wraps the consumer side of the pipeline; it still supplies the client used by Rails to enqueue jobs. The Active Job executor is appended automatically and should not be added to the definition.
-
-## Common Pitfalls
-
-### A Queue Name Raises `KeyError`
-
-The name selected by `queue_as` does not have a matching definition or alias. Add it with `config.async_job.define_queue` or route it with `config.async_job.alias_queue`.
-
-### Separate Definitions Consume the Same Jobs
-
-Redis definitions with the same endpoint and prefix share the same underlying queue. Assign a distinct prefix to every independently processed definition.
-
-### A Worker Selection Uses an Alias
-
-`ASYNC_JOB_ADAPTER_ACTIVE_JOB_QUEUE_NAMES` accepts definition names, not aliases. Select `default`, for example, rather than an alias such as `mailers`.

--- a/guides/queue-configuration/readme.md
+++ b/guides/queue-configuration/readme.md
@@ -36,8 +36,6 @@ end
 
 Processors can accept positional and keyword arguments after the processor class. Use an application-, environment-, and queue-specific Redis prefix so unrelated workloads do not consume each other's jobs.
 
-The Redis processor comes from the separate `async-job-processor-redis` gem. See [Production Deployment](../production-deployment/index) for installation and worker operation.
-
 ## Defining Multiple Queues
 
 Multiple definitions allow independent worker groups to process different workloads. For example, payment capture can use a dedicated queue while ordinary work remains on `default`:

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,9 @@ Provides an adapter for ActiveJob on top of `Async::Job`.
 
 Please see the [project documentation](https://socketry.github.io/async-job-adapter-active_job/) for more details.
 
-  - [Getting Started](https://socketry.github.io/async-job-adapter-active_job/guides/getting-started/index) - This guide explains how to get started with the `async-job-adapter-active_job` gem.
+  - [Getting Started](https://socketry.github.io/async-job-adapter-active_job/guides/getting-started/index) - This guide explains how to run Rails Active Job workloads with inline or Redis-backed queues.
+  - [Production Deployment](https://socketry.github.io/async-job-adapter-active_job/guides/production-deployment/index) - This guide explains how to deploy Redis-backed queues and separate worker processes.
+  - [Queue Configuration](https://socketry.github.io/async-job-adapter-active_job/guides/queue-configuration/index) - This guide explains how to configure queues, aliases, and per-job routing.
 
 ## Releases
 


### PR DESCRIPTION
## Summary

- rewrite Getting Started around core concepts and a minimal inline quick start
- explain that Redis defaults every queue definition to the `async-job` prefix
- add a Production Deployment guide for Redis-backed queues, separate workers, and deployment checks
- add a Queue Configuration guide covering prefix isolation, definitions, aliases, multiple queues, per-job adoption, and pipeline behavior
- use realistic Active Job examples with retry and discard behavior
- replace obsolete class references and synchronize the packaged context guides
- expose all three guides through the project documentation index and README

## Verification

- RuboCop passes for all changed Markdown guides and the project README
- all documented Ruby snippets parse successfully with Prism
- guide metadata parses successfully as YAML
- source guides and packaged context copies match
- `git diff --check` passes
- full bundled test suite not run because the locked bundle is not installed in the workspace
