### PR TITLE
Fix documentation coverage

### DIFF
--- a/lib/async/job/adapter/active_job/dispatcher.rb
+++ b/lib/async/job/adapter/active_job/dispatcher.rb
@@ -61,6 +61,8 @@ module Async
 						@definitions.keys
 					end
 					
+					# Generate a summary of the configured queues and their server status.
+					# @returns [String] A comma-separated summary of all configured queues.
 					def status_string
 						self.keys.map do |name|
 							queue = @queues[name]


### PR DESCRIPTION
## Summary

- document `Async::Job::Adapter::ActiveJob::Dispatcher#status_string`
- describe its queue status summary return value

## Verification

- Decode reports 45 documented definitions out of 45 public definitions
- RuboCop passes for the changed file
- `git diff --check` passes
