### PR TITLE
Fix Ruby 3.3 test logging

### DIFF
--- a/config/sus.rb
+++ b/config/sus.rb
@@ -9,4 +9,6 @@ include Covered::Sus
 # Redirect log output:
 require "console/adapter/rails/logger"
 require "active_job"
-ActiveJob::Base.logger = Console::Adapter::Rails::Logger.new(Console)
+ActiveJob::Base.logger = ActiveSupport::TaggedLogging.new(
+	Console::Adapter::Rails::Logger.new(Console)
+)


### PR DESCRIPTION
## Summary

- wrap the Active Job test logger with `ActiveSupport::TaggedLogging`
- ensure `console-adapter-rails` always has tag metadata when forwarding log messages
- avoid the Ruby 3.3 `**nil` failure that masked job logging assertions

## Testing

- Ruby 3.3.10 with Rails 8.1.3.1 and console-adapter-rails 0.6.0: 33 tests passed (112 assertions)
- `git diff --check`