### PR TITLE
Document Redis endpoint configuration

### DIFF
--- a/context/production-deployment.md
+++ b/context/production-deployment.md
@@ -31,14 +31,22 @@ Replace the built-in `default` queue definition in `config/initializers/async_jo
 ```ruby
 require "async/job/processor/redis"
 
+redis_endpoint = Async::Redis::Endpoint.parse(ENV.fetch("REDIS_URL"))
+
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis
+		dequeue Async::Job::Processor::Redis, endpoint: redis_endpoint
 	end
 end
 ```
 
-The processor connects to Redis on its local default endpoint unless another endpoint is provided. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
+Set `REDIS_URL` in both the Rails and worker process environments. It may use the `redis://` or `rediss://` scheme and include credentials, a port, and a database number:
+
+```shell
+$ REDIS_URL=redis://redis.example.com:6379/0 bundle exec async-job-adapter-active_job-server
+```
+
+Without an explicit endpoint, the processor connects to `redis://localhost:6379`. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
 
 ## Starting Workers
 

--- a/context/queue-configuration.md
+++ b/context/queue-configuration.md
@@ -36,6 +36,24 @@ end
 
 Processors can accept positional and keyword arguments after the processor class.
 
+## Redis Endpoints
+
+Without an explicit `endpoint`, the Redis processor connects to `redis://localhost:6379`. Pass an ruby:`Async::Redis::Endpoint` when Redis runs on another host, requires credentials, uses a different database, or accepts TLS connections:
+
+```ruby
+redis_endpoint = Async::Redis::Endpoint.parse(ENV.fetch("REDIS_URL"))
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, endpoint: redis_endpoint
+	end
+end
+```
+
+`REDIS_URL` may use either the `redis://` or `rediss://` scheme and can include credentials, a port, and a database number, for example `redis://username:password@redis.example.com:6379/1`. Keep credentials in the environment rather than writing them into the initializer.
+
+The bundled worker loads the Rails environment, so Rails and worker processes use the same queue definition. Ensure `REDIS_URL` is present and identical in both process environments.
+
 ## Redis Prefixes
 
 Without an explicit `prefix`, every Redis processor uses `async-job`. Queue definition names do not alter that default, so two definitions using the same Redis endpoint and prefix operate on the same underlying queue.

--- a/guides/production-deployment/readme.md
+++ b/guides/production-deployment/readme.md
@@ -31,14 +31,22 @@ Replace the built-in `default` queue definition in `config/initializers/async_jo
 ```ruby
 require "async/job/processor/redis"
 
+redis_endpoint = Async::Redis::Endpoint.parse(ENV.fetch("REDIS_URL"))
+
 Rails.application.configure do
 	config.async_job.define_queue "default" do
-		dequeue Async::Job::Processor::Redis
+		dequeue Async::Job::Processor::Redis, endpoint: redis_endpoint
 	end
 end
 ```
 
-The processor connects to Redis on its local default endpoint unless another endpoint is provided. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
+Set `REDIS_URL` in both the Rails and worker process environments. It may use the `redis://` or `rediss://` scheme and include credentials, a port, and a database number:
+
+```shell
+$ REDIS_URL=redis://redis.example.com:6379/0 bundle exec async-job-adapter-active_job-server
+```
+
+Without an explicit endpoint, the processor connects to `redis://localhost:6379`. With one logical queue, the default `async-job` prefix is sufficient. Configure distinct, stable prefixes when multiple queue definitions share a Redis endpoint.
 
 ## Starting Workers
 

--- a/guides/queue-configuration/readme.md
+++ b/guides/queue-configuration/readme.md
@@ -36,6 +36,24 @@ end
 
 Processors can accept positional and keyword arguments after the processor class.
 
+## Redis Endpoints
+
+Without an explicit `endpoint`, the Redis processor connects to `redis://localhost:6379`. Pass an ruby:`Async::Redis::Endpoint` when Redis runs on another host, requires credentials, uses a different database, or accepts TLS connections:
+
+```ruby
+redis_endpoint = Async::Redis::Endpoint.parse(ENV.fetch("REDIS_URL"))
+
+Rails.application.configure do
+	config.async_job.define_queue "default" do
+		dequeue Async::Job::Processor::Redis, endpoint: redis_endpoint
+	end
+end
+```
+
+`REDIS_URL` may use either the `redis://` or `rediss://` scheme and can include credentials, a port, and a database number, for example `redis://username:password@redis.example.com:6379/1`. Keep credentials in the environment rather than writing them into the initializer.
+
+The bundled worker loads the Rails environment, so Rails and worker processes use the same queue definition. Ensure `REDIS_URL` is present and identical in both process environments.
+
 ## Redis Prefixes
 
 Without an explicit `prefix`, every Redis processor uses `async-job`. Queue definition names do not alter that default, so two definitions using the same Redis endpoint and prefix operate on the same underlying queue.


### PR DESCRIPTION
## Summary

- configure Redis-backed queues from `REDIS_URL` in the production deployment example
- document the default `redis://localhost:6379` endpoint
- explain `redis://` and `rediss://` URLs, credentials, ports, and database selection
- clarify that Rails and worker processes must receive the same endpoint configuration

Fixes #11

## Validation

- `bundle exec rubocop`
- guide pages rendered successfully during the static build; local Pagefind indexing failed afterward in npm
- `bundle exec bake test` (32/33 pass; one unrelated Ruby 4 error-message assertion fails)